### PR TITLE
fix map disappearing bug when using deep linking

### DIFF
--- a/src/pages/home/home.ts
+++ b/src/pages/home/home.ts
@@ -278,6 +278,7 @@ export class HomePage {
 
       //Join the room specified by the group uid.
       this.groupSocketService.joinGroup();
+      this.navCtrl.pop();
     }
   }
 


### PR DESCRIPTION
The deep linking currently loads two homepages, this destroys the second one when joining a group.